### PR TITLE
chore(node-version): drop support for node v10

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         node:
-          - 10
+          - '12.17'
           - 12
           - 14
     steps:

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "description": "opinionated scaffolder for adding a JavaScript package to an existing monorepo",
   "license": "MIT",
   "version": "0.0.0-semantically-released",
+  "engines": {
+    "node": ">=12.17"
+  },
   "files": [
     "example.js",
     "lib/"


### PR DESCRIPTION
since it is now EOL

BREAKING CHANGE: the minimum node version has been raised to v12.17